### PR TITLE
Allow keyword args for initialize_with

### DIFF
--- a/lib/mandate/initializer_injector.rb
+++ b/lib/mandate/initializer_injector.rb
@@ -2,14 +2,22 @@ module Mandate
   module InitializerInjector
     def self.extended(base)
       class << base
-        def initialize_with(*attrs)
-          define_method :initialize do |*args|
+        def initialize_with(*attrs,**kwattrs)
+          define_method :initialize do |*args,**kwargs|
             unless args.length == attrs.length
-              raise ArgumentError.new("Wrong number of arguments (given #{args.length}, expected #{attrs.length})")
+              raise ArgumentError.new("wrong number of arguments (given #{args.length}, expected #{attrs.length})")
             end
 
             attrs.zip(args).each do |attr,arg|
               instance_variable_set("@#{attr}", arg)
+            end
+
+            kwargs.each do |name,value|
+              if kwattrs.keys.include?(name)
+                instance_variable_set("@#{name}", value)
+              else
+                raise ArgumentError.new("unknown keyword: #{name}")
+              end
             end
           end
 
@@ -17,10 +25,19 @@ module Mandate
             define_method attr do instance_variable_get("@#{attr}") end
             private attr
           end
+
+          kwattrs.each do |attr,default|
+            define_method attr do
+              if instance_variable_defined?("@#{attr}")
+                instance_variable_get("@#{attr}")
+              else
+                default
+              end
+            end
+            private attr
+          end
         end
       end
     end
   end
 end
-
-

--- a/test/initializer_test.rb
+++ b/test/initializer_test.rb
@@ -12,11 +12,16 @@ class InitializerTest < Minitest::Test
     initialize_with :foo, :bar
   end
 
+  class KeywordStorer
+    include Mandate
+    initialize_with :foo, bar: ["default"]
+  end
+
   def test_initializes_properly_without_args
     BoringStorer.new
   end
 
-  def test_initializes_properly
+  def test_initializes_properly_with_args
     foo = "fooooo"
     bar = "baaarrrr"
     storer = ArgumentativeStorer.new(foo, bar)
@@ -24,9 +29,30 @@ class InitializerTest < Minitest::Test
     assert_equal bar, storer.send(:bar)
   end
 
+  def test_initializes_properly_with_keyword_args
+    foo = "fooooo"
+    bar = "baaarrrr"
+    storer = KeywordStorer.new(foo, bar: bar)
+    assert_equal foo, storer.send(:foo)
+    assert_equal bar, storer.send(:bar)
+  end
+
+  def test_initializes_properly_with_a_missing_keyword_arg
+    foo = "fooooo"
+    storer = KeywordStorer.new(foo)
+    assert_equal foo, storer.send(:foo)
+    assert_equal ["default"], storer.send(:bar)
+  end
+
   def test_raises_with_wrong_amount_of_args
     assert_raises ArgumentError do
       ArgumentativeStorer.new(nil)
+    end
+  end
+
+  def test_raises_with_wrong_keyword_args
+    assert_raises ArgumentError do
+      KeywordStorer.new("foo", qux: "bar")
     end
   end
 

--- a/test/initializer_test.rb
+++ b/test/initializer_test.rb
@@ -14,7 +14,7 @@ class InitializerTest < Minitest::Test
 
   class KeywordStorer
     include Mandate
-    initialize_with :foo, bar: ["default"]
+    initialize_with :foo, bar: "default"
   end
 
   def test_initializes_properly_without_args
@@ -41,7 +41,7 @@ class InitializerTest < Minitest::Test
     foo = "fooooo"
     storer = KeywordStorer.new(foo)
     assert_equal foo, storer.send(:foo)
-    assert_equal ["default"], storer.send(:bar)
+    assert_equal "default", storer.send(:bar)
   end
 
   def test_raises_with_wrong_amount_of_args


### PR DESCRIPTION
Method starts getting a bit long. And the naming of the variables is a bit iffy.