### PR TITLE
Add success/failure callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# 0.3.0 / 2019-09-06
+* [FEATURE] Add success/failure callbacks
+
 # 0.2.0 / 2018-08-11
 * [FEATURE] Add initialize_with

--- a/README.md
+++ b/README.md
@@ -81,17 +81,15 @@ class Sumer
 end
 
 cmd = Sumer.(1,2)
-cmd.success{ |result| p result }
-cmd.failure{ |errors| p errors }
-# => 3
+cmd.success { |result| p result } # puts 3
+cmd.failure { |errors| p errors } # Noop
 
 cmd = Sumer.("1","2")
-cmd.success{ |result| p result }
-cmd.failure{ |errors| p errors }
-# => ["num1 must be an Integer"]
+cmd.success { |result| p result } # Noop
+cmd.failure { |errors| p errors } # puts ["num1 must be an Integer"]
 ```
 
-Rather than using `abort!` with an error, it is also possible to add errors as you go then abort if you find any. 
+Rather than using `abort!` with an error, it is also possible to add errors as you go then abort if you find any.
 For example:
 
 ```ruby
@@ -111,14 +109,12 @@ class Sumer
 end
 
 cmd = Sumer.(1,2)
-cmd.success{ |result| p result }
-cmd.failure{ |errors| p errors }
-# => 3
+cmd.success { |result| p result } # puts 3
+cmd.failure { |errors| p errors } # Noop
 
 cmd = Sumer.("1","2")
-cmd.success{ |result| p result }
-cmd.failure{ |errors| p errors }
-# => ["num1 must be an Integer", "num2 must be an Integer"]
+cmd.success { |result| p result } # Noop
+cmd.failure { |errors| p errors } # puts ["num1 must be an Integer", "num2 must be an Integer"]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ private
 attr_reader :foo, :bar
 ```
 
-### Using success/failure callbacks
+### Using on_success/on_failure callbacks
 
-Sometimes it is helpful for the class to return success/failure callbacks rather than just the resulting value.
+Sometimes it is helpful for the class to return on_success/on_failure callbacks rather than just the resulting value.
 This can be achieved by including the `Mandate::Callbacks` module as follows:
 
 ```ruby
@@ -80,44 +80,31 @@ class Sumer
   end
 end
 
-cmd = Sumer.(1,2)
-cmd.success { |result| p result } # puts 3
-cmd.failure { |errors| p errors } # Noop
-cmd.succeeded? # true
-cmd.result # 3
-cmd.errors # []
+res = Sumer.(1,2)
+res.on_success { |result| p result } # puts 3
+res.on_failure { |errors| p errors } # Noop
+res.succeeded? # true
+res.result # 3
+res.errors # []
 
-cmd = Sumer.("1","2")
-cmd.success { |result| p result } # Noop
-cmd.failure { |errors| p errors } # puts ["num1 must be an Integer"]
-cmd.succeeded? # false
-cmd.result # nil
-cmd.errors # ["num1 must be an Integer"]
+res = Sumer.("1","2")
+res.on_success { |result| p result } # Noop
+res.on_failure { |errors| p errors } # puts ["num1 must be an Integer"]
+
+res = Sumer.("1","2")
+res.on_failure { |errors| p errors } # puts ["num1 must be an Integer", "num2 must be an Integer"]
+res.errors # ["num1 must be an Integer", "num2 must be an Integer"]
 ```
 
-Rather than using `abort!` with an error, it is also possible to add errors as you go then abort if you find any.
-For example:
+It is also possible to chain methods, for example:
 
 ```ruby
-class Sumer
-  include Mandate
-  include Mandate::Callbacks
-
-  initialize_with :num1, :num2
-
-  def call
-    add_error!("num1 must be an Integer") unless num1.is_a?(Integer)
-    add_error!("num2 must be an Integer") unless num2.is_a?(Integer)
-    abort_if_errored!
-
-    num1 + num2
-  end
-end
-
-cmd = Sumer.("1","2")
-cmd.failure { |errors| p errors } # puts ["num1 must be an Integer", "num2 must be an Integer"]
-cmd.errors # ["num1 must be an Integer", "num2 must be an Integer"]
+Sumer.(1,2).
+  on_success { |result| p result }.
+  on_failure { |errors| p errors }
 ```
+
+The `succeeded?` method is also aliased as `success?`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,16 @@ end
 cmd = Sumer.(1,2)
 cmd.success { |result| p result } # puts 3
 cmd.failure { |errors| p errors } # Noop
+cmd.succeeded? # true
+cmd.result # 3
+cmd.errors # []
 
 cmd = Sumer.("1","2")
 cmd.success { |result| p result } # Noop
 cmd.failure { |errors| p errors } # puts ["num1 must be an Integer"]
+cmd.succeeded? # false
+cmd.result # nil
+cmd.errors # ["num1 must be an Integer"]
 ```
 
 Rather than using `abort!` with an error, it is also possible to add errors as you go then abort if you find any.
@@ -108,13 +114,9 @@ class Sumer
   end
 end
 
-cmd = Sumer.(1,2)
-cmd.success { |result| p result } # puts 3
-cmd.failure { |errors| p errors } # Noop
-
 cmd = Sumer.("1","2")
-cmd.success { |result| p result } # Noop
 cmd.failure { |errors| p errors } # puts ["num1 must be an Integer", "num2 must be an Integer"]
+cmd.errors # ["num1 must be an Integer", "num2 must be an Integer"]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -60,6 +60,67 @@ private
 attr_reader :foo, :bar
 ```
 
+### Using success/failure callbacks
+
+Sometimes it is helpful for the class to return success/failure callbacks rather than just the resulting value.
+This can be achieved by including the `Mandate::Callbacks` module as follows:
+
+```ruby
+class Sumer
+  include Mandate
+  include Mandate::Callbacks
+
+  initialize_with :num1, :num2
+
+  def call
+    abort!("num1 must be an Integer") unless num1.is_a?(Integer)
+    abort!("num2 must be an Integer") unless num2.is_a?(Integer)
+
+    num1 + num2
+  end
+end
+
+cmd = Sumer.(1,2)
+cmd.success{ |result| p result }
+cmd.failure{ |errors| p errors }
+# => 3
+
+cmd = Sumer.("1","2")
+cmd.success{ |result| p result }
+cmd.failure{ |errors| p errors }
+# => ["num1 must be an Integer"]
+```
+
+Rather than using `abort!` with an error, it is also possible to add errors as you go then abort if you find any. 
+For example:
+
+```ruby
+class Sumer
+  include Mandate
+  include Mandate::Callbacks
+
+  initialize_with :num1, :num2
+
+  def call
+    add_error!("num1 must be an Integer") unless num1.is_a?(Integer)
+    add_error!("num2 must be an Integer") unless num2.is_a?(Integer)
+    abort_if_errored!
+
+    num1 + num2
+  end
+end
+
+cmd = Sumer.(1,2)
+cmd.success{ |result| p result }
+cmd.failure{ |errors| p errors }
+# => 3
+
+cmd = Sumer.("1","2")
+cmd.success{ |result| p result }
+cmd.failure{ |errors| p errors }
+# => ["num1 must be an Integer", "num2 must be an Integer"]
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/mandate.rb
+++ b/lib/mandate.rb
@@ -2,6 +2,7 @@ require "mandate/version"
 require "mandate/memoize"
 require "mandate/call_injector"
 require "mandate/initializer_injector"
+require "mandate/callbacks"
 
 module Mandate
   def self.included(base)

--- a/lib/mandate/callbacks.rb
+++ b/lib/mandate/callbacks.rb
@@ -21,7 +21,7 @@ module Mandate
     end
 
     def self.extended(base)
-      base.define_method(:call_with_callbacks) do
+      base.send(:define_method, :call_with_callbacks) do
         begin
 
           # Setup
@@ -40,28 +40,28 @@ module Mandate
         end
       end
 
-      base.define_method(:success) do |&block|
+      base.send(:define_method, :success) do |&block|
         return unless @__mandate_success
         block.call(@__mandate_result)
       end
 
-      base.define_method(:failure) do |&block|
+      base.send(:define_method, :failure) do |&block|
         return if @__mandate_success
         block.call(@__mandate_errors)
       end
 
       private
 
-      base.define_method(:add_error!) do |error|
+      base.send(:define_method, :add_error!) do |error|
         @__mandate_errors << error
       end
 
-      base.define_method(:abort!) do |error = nil|
+      base.send(:define_method, :abort!) do |error = nil|
         add_error!(error) if error
         raise AbortError
       end
 
-      base.define_method(:abort_if_errored!) do
+      base.send(:define_method, :abort_if_errored!) do
         raise AbortError if @__mandate_errors.size > 0
       end
     end

--- a/lib/mandate/callbacks.rb
+++ b/lib/mandate/callbacks.rb
@@ -22,20 +22,22 @@ module Mandate
 
     def self.extended(base)
       base.define_method(:call_with_callbacks) do
+        begin
 
-        # Setup
-        @__mandate_errors = []
-        @__mandate_success = false
+          # Setup
+          @__mandate_errors = []
+          @__mandate_success = false
 
-        # Run the actual command
-        @__mandate_result = call
+          # Run the actual command
+          @__mandate_result = call
 
-        # It's succeed so let's set this flag
-        @__mandate_success = true
-        self
+          # It's succeed so let's set this flag
+          @__mandate_success = true
+          self
 
-      rescue AbortError
-        self
+        rescue AbortError
+          self
+        end
       end
 
       base.define_method(:success) do |&block|

--- a/lib/mandate/callbacks.rb
+++ b/lib/mandate/callbacks.rb
@@ -1,0 +1,67 @@
+module Mandate
+  module Callbacks
+    class AbortError < RuntimeError
+    end
+
+    def self.included(base)
+      # Override self.call to call the internal call_with_callbacks
+      # function which returns a method with success/failure callbacks
+      class << base
+        # Remove the existing created by the "include Mandate"
+        remove_method(:call)
+
+        # Define a new call methods which calls the instance call
+        # method but with the added callbacks needed for success/failure
+        def call(*args)
+          new(*args).call_with_callbacks
+        end
+      end
+
+      base.extend(Callbacks)
+    end
+
+    def self.extended(base)
+      base.define_method(:call_with_callbacks) do
+
+        # Setup
+        @__mandate_errors = []
+        @__mandate_success = false
+
+        # Run the actual command
+        @__mandate_result = call
+
+        # It's succeed so let's set this flag
+        @__mandate_success = true
+        self
+
+      rescue AbortError
+        self
+      end
+
+      base.define_method(:success) do |&block|
+        return unless @__mandate_success
+        block.call(@__mandate_result)
+      end
+
+      base.define_method(:failure) do |&block|
+        return if @__mandate_success
+        block.call(@__mandate_errors)
+      end
+
+      private
+
+      base.define_method(:add_error!) do |error|
+        @__mandate_errors << error
+      end
+
+      base.define_method(:abort!) do |error = nil|
+        add_error!(error) if error
+        raise AbortError
+      end
+
+      base.define_method(:abort_if_errored!) do
+        raise AbortError if @__mandate_errors.size > 0
+      end
+    end
+  end
+end

--- a/lib/mandate/callbacks.rb
+++ b/lib/mandate/callbacks.rb
@@ -23,15 +23,16 @@ module Mandate
       def succeeded?
         !!succeeded
       end
+      alias_method :success?, :succeeded?
 
-      def success(&block)
-        return unless succeeded?
-        block.call(result)
+      def on_success(&block)
+        block.call(result) if succeeded?
+        self
       end
 
-      def failure(&block)
-        return if succeeded?
-        block.call(errors)
+      def on_failure(&block)
+        block.call(errors) unless succeeded?
+        self
       end
 
       private
@@ -40,13 +41,13 @@ module Mandate
 
     def self.included(base)
       # Override self.call to call the internal call_with_callbacks
-      # function which returns a method with success/failure callbacks
+      # function which returns a method with on_success/on_failure callbacks
       class << base
         # Remove the existing created by the "include Mandate"
         remove_method(:call)
 
         # Define a new call methods which calls the instance call
-        # method but with the added callbacks needed for success/failure
+        # method but with the added callbacks needed for on_success/on_failure
         def call(*args)
           new(*args).call_with_callbacks
         end

--- a/lib/mandate/version.rb
+++ b/lib/mandate/version.rb
@@ -1,3 +1,3 @@
 module Mandate
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class InitializerInjectorTest < Minitest::Test
+  class Sumer
+    include Mandate
+    include Mandate::Callbacks
+
+    initialize_with :foo, :bar, :succeed
+
+    def call
+      if succeed
+        abort_if_errored! # This should be a noop
+        foo + bar
+      else
+        abort!("Something bad happened")
+      end
+    end
+  end
+
+  class MultipleErrors
+    include Mandate
+    include Mandate::Callbacks
+
+    def call
+      add_error!("Something bad happened")
+      add_error!("Something else bad happened")
+      abort_if_errored!
+    end
+  end
+
+  def test_success_works_properly
+    cmd = Sumer.(10, 5, true)
+    cmd.success { |res| assert_equal 15, res }
+    cmd.failure { flunk } # This block should never be called
+  end
+
+  def test_failure_works_properly
+    cmd = Sumer.(10, 5, false)
+    cmd.success { flunk } # This block should never be called
+    cmd.failure do |errors|
+      assert_equal errors, ["Something bad happened"]
+    end
+  end
+
+  def test_multiple_errors
+    cmd = MultipleErrors.()
+    cmd.success { flunk } # This block should never be called
+    cmd.failure do |errors|
+      assert_equal errors,  [
+        "Something bad happened",
+        "Something else bad happened"
+      ]
+    end
+  end
+
+end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -28,29 +28,46 @@ class InitializerInjectorTest < Minitest::Test
     end
   end
 
-  def test_success_works_properly
+  def test_on_success_works_properly
     cmd = Sumer.(10, 5, true)
-    cmd.success { |res| assert_equal 15, res }
-    cmd.failure { flunk } # This block should never be called
+    cmd.on_success { |res| assert_equal 15, res }
+    cmd.on_failure { flunk } # This block should never be called
   end
 
-  def test_failure_works_properly
+  def test_on_failure_works_properly
     cmd = Sumer.(10, 5, false)
-    cmd.success { flunk } # This block should never be called
-    cmd.failure do |errors|
+    cmd.on_success { flunk } # This block should never be called
+    cmd.on_failure do |errors|
       assert_equal errors, ["Something bad happened"]
     end
   end
 
   def test_multiple_errors
     cmd = MultipleErrors.()
-    cmd.success { flunk } # This block should never be called
-    cmd.failure do |errors|
+    cmd.on_success { flunk } # This block should never be called
+    cmd.on_failure do |errors|
       assert_equal errors,  [
         "Something bad happened",
         "Something else bad happened"
       ]
     end
+  end
+
+  def test_chaining
+    res1 = Sumer.(10, 5, true)
+    res2 = res1.on_success { |res| assert_equal 15, res }
+    res3 = res1.on_failure { flunk }
+
+    assert_equal res1, res2
+    assert_equal res1, res3
+    assert_equal res2, res3
+  end
+
+  def test_succeededd_and_success
+    assert Sumer.(10, 5, true).succeeded?
+    assert Sumer.(10, 5, true).success?
+    refute Sumer.(10, 5, false).succeeded?
+    refute Sumer.(10, 5, false).success?
   end
 
 end


### PR DESCRIPTION
Sometimes it is helpful for the class to return success/failure callbacks rather than just the resulting value. This can now be achieved by including the `Mandate::Callbacks` module. 

See README changes for example usage.