### PR TITLE
Add keyword args

### DIFF
--- a/lib/mandate/call_injector.rb
+++ b/lib/mandate/call_injector.rb
@@ -7,6 +7,9 @@ module Mandate
       #   Foobar.new(some, args).call()
       class << base
         def call(*args)
+          # If the last argument is a hash and the last param is a keyword params (signified by 
+          # its type being :key, the we should pass the hash in in using the **kwords syntax.
+          # This fixes a deprecation issue in Ruby 2.7.
           if args.last.is_a?(Hash) && 
             :key == instance_method(:initialize).parameters.last&.first
             new(*args[0..-2], **args[-1]).call

--- a/lib/mandate/call_injector.rb
+++ b/lib/mandate/call_injector.rb
@@ -7,7 +7,12 @@ module Mandate
       #   Foobar.new(some, args).call()
       class << base
         def call(*args)
-          new(*args).call
+          if args.last.is_a?(Hash) && 
+            :key == instance_method(:initialize).parameters.last&.first
+            new(*args[0..-2], **args[-1]).call
+          else
+            new(*args).call
+          end
         end
       end
     end

--- a/lib/mandate/callbacks.rb
+++ b/lib/mandate/callbacks.rb
@@ -71,20 +71,21 @@ module Mandate
         @__mandate_results
       end
 
-      private
-
       base.send(:define_method, :add_error!) do |error|
         @__mandate_results.add_error(error)
       end
+      base.send(:private, :add_error!)
 
       base.send(:define_method, :abort!) do |error = nil|
         add_error!(error) if error
         raise AbortError
       end
+      base.send(:private, :abort!)
 
       base.send(:define_method, :abort_if_errored!) do
         raise AbortError if @__mandate_results.errors.size > 0
       end
+      base.send(:private, :abort_if_errored!)
     end
   end
 end

--- a/lib/mandate/initializer_injector.rb
+++ b/lib/mandate/initializer_injector.rb
@@ -2,21 +2,33 @@ module Mandate
   module InitializerInjector
     def self.extended(base)
       class << base
-        def initialize_with(*attrs,**kwattrs)
-          define_method :initialize do |*args,**kwargs|
-            unless args.length == attrs.length
-              raise ArgumentError.new("wrong number of arguments (given #{args.length}, expected #{attrs.length})")
-            end
+        def initialize_with(*attrs, **kwattrs)
+          if kwattrs.empty?
+            define_method :initialize do |*args|
+              unless args.length == attrs.length
+                raise ArgumentError.new("wrong number of arguments (given #{args.length}, expected #{attrs.length})")
+              end
 
-            attrs.zip(args).each do |attr,arg|
-              instance_variable_set("@#{attr}", arg)
+              attrs.zip(args).each do |attr,arg|
+                instance_variable_set("@#{attr}", arg)
+              end
             end
+          else
+            define_method :initialize do |*args, **kwargs|
+              unless args.length == attrs.length
+                raise ArgumentError.new("wrong number of arguments (given #{args.length}, expected #{attrs.length})")
+              end
 
-            kwargs.each do |name,value|
-              if kwattrs.keys.include?(name)
-                instance_variable_set("@#{name}", value)
-              else
-                raise ArgumentError.new("unknown keyword: #{name}")
+              attrs.zip(args).each do |attr,arg|
+                instance_variable_set("@#{attr}", arg)
+              end
+
+              kwargs.each do |name,value|
+                if kwattrs.keys.include?(name)
+                  instance_variable_set("@#{name}", value)
+                else
+                  raise ArgumentError.new("unknown keyword: #{name}")
+                end
               end
             end
           end

--- a/lib/mandate/initializer_injector.rb
+++ b/lib/mandate/initializer_injector.rb
@@ -2,14 +2,22 @@ module Mandate
   module InitializerInjector
     def self.extended(base)
       class << base
-        def initialize_with(*attrs)
-          define_method :initialize do |*args|
+        def initialize_with(*attrs,**kwattrs)
+          define_method :initialize do |*args,**kwargs|
             unless args.length == attrs.length
-              raise ArgumentError.new("Wrong number of arguments (given #{args.length}, expected #{attrs.length})")
+              raise ArgumentError.new("wrong number of arguments (given #{args.length}, expected #{attrs.length})")
             end
 
             attrs.zip(args).each do |attr,arg|
               instance_variable_set("@#{attr}", arg)
+            end
+
+            kwargs.each do |name,value|
+              if kwattrs.keys.include?(name)
+                instance_variable_set("@#{name}", value)
+              else
+                raise ArgumentError.new("unknown keyword: #{name}")
+              end
             end
           end
 
@@ -17,10 +25,19 @@ module Mandate
             define_method attr do instance_variable_get("@#{attr}") end
             private attr
           end
+
+          kwattrs.each do |attr,default|
+            define_method attr do
+              if instance_variable_defined?("@#{attr}")
+                instance_variable_get("@#{attr}")
+              else
+                default
+              end
+            end
+            private attr
+          end
         end
       end
     end
   end
 end
-
-

--- a/lib/mandate/version.rb
+++ b/lib/mandate/version.rb
@@ -1,3 +1,3 @@
 module Mandate
-  VERSION = "0.3.0"
+  VERSION = "0.4.0.beta.1"
 end

--- a/mandate.gemspec
+++ b/mandate.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/test/call_injector_test.rb
+++ b/test/call_injector_test.rb
@@ -16,6 +16,60 @@ class CallInjectorTest < Minitest::Test
     end
   end
 
+  class OneSumer
+    include Mandate
+
+    def initialize
+    end
+
+    def call
+      1
+    end
+  end
+
+  class KwargsSummer
+    include Mandate
+
+    attr_reader :a, :b
+    def initialize(a, b:1)
+      @a = a
+      @b = b
+    end
+
+    def call
+      a+b
+    end
+  end
+
+  class SplatKwargsSummer
+    include Mandate
+
+    attr_reader :a, :b, :other
+    def initialize(a, *other, b:1)
+      @a = a
+      @b = b
+      @other = (other || [])
+    end
+
+    def call
+      a+b+other.inject(:+).to_i
+    end
+  end
+
+  class WeirdPrinter
+    include Mandate
+
+    attr_reader :a, :b
+    def initialize(a, b)
+      @a = a
+      @b = b
+    end
+
+    def call
+      "#{a} #{b.keys.join} #{b.values.join}"
+    end
+  end
+
   class BadConstant
     include Mandate
 
@@ -34,4 +88,22 @@ class CallInjectorTest < Minitest::Test
     end
   end
 
+  def test_call_works_with_kwargs
+    assert_equal 11, KwargsSummer.(10)
+    assert_equal 15, KwargsSummer.(10, b: 5)
+  end
+
+  def test_call_works_with_splat_kwargs
+    assert_equal 2, SplatKwargsSummer.(1)
+    assert_equal 3, SplatKwargsSummer.(1, b: 2)
+    assert_equal 15, SplatKwargsSummer.(1, 2, 4, b: 8)
+  end
+
+  def test_hash_as_final_param
+    assert_equal "a b c", WeirdPrinter.("a", {b: "c"})
+  end
+
+  def test_empty_intitializer
+    assert_equal 1, OneSumer.()
+  end
 end

--- a/test/call_injector_test.rb
+++ b/test/call_injector_test.rb
@@ -70,6 +70,15 @@ class CallInjectorTest < Minitest::Test
     end
   end
 
+  class WeirdPrinterInitialized
+    include Mandate
+    initialize_with :a, :b
+
+    def call
+      "#{a} #{b.keys.join} #{b.values.join}"
+    end
+  end
+
   class BadConstant
     include Mandate
 
@@ -101,6 +110,10 @@ class CallInjectorTest < Minitest::Test
 
   def test_hash_as_final_param
     assert_equal "a b c", WeirdPrinter.("a", {b: "c"})
+  end
+
+  def test_hash_with_initialize_with
+    assert_equal "a b c", WeirdPrinterInitialized.("a", {b: "c"})
   end
 
   def test_empty_intitializer

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -70,4 +70,16 @@ class InitializerInjectorTest < Minitest::Test
     refute Sumer.(10, 5, false).success?
   end
 
+  def test_private_methods_are_private
+    obj = Sumer.new(10, 5, true)
+    exp = assert_raises(NoMethodError) { obj.add_error!(nil) }
+    assert exp.message.include?("private method")
+
+    exp = assert_raises(NoMethodError) { obj.abort! }
+    assert exp.message.include?("private method")
+
+    exp = assert_raises(NoMethodError) { obj.abort_if_errored! }
+    assert exp.message.include?("private method")
+  end
+
 end

--- a/test/initializer_injector_test.rb
+++ b/test/initializer_injector_test.rb
@@ -14,7 +14,7 @@ class InitializerInjectorTest < Minitest::Test
 
   class KeywordStorer
     include Mandate
-    initialize_with :foo, bar: ["default"]
+    initialize_with :foo, bar: "default"
   end
 
   def test_initializes_properly_without_args
@@ -41,7 +41,7 @@ class InitializerInjectorTest < Minitest::Test
     foo = "fooooo"
     storer = KeywordStorer.new(foo)
     assert_equal foo, storer.send(:foo)
-    assert_equal ["default"], storer.send(:bar)
+    assert_equal "default", storer.send(:bar)
   end
 
   def test_raises_with_wrong_amount_of_args

--- a/test/initializer_injector_test.rb
+++ b/test/initializer_injector_test.rb
@@ -12,11 +12,16 @@ class InitializerInjectorTest < Minitest::Test
     initialize_with :foo, :bar
   end
 
+  class KeywordStorer
+    include Mandate
+    initialize_with :foo, bar: ["default"]
+  end
+
   def test_initializes_properly_without_args
     BoringStorer.new
   end
 
-  def test_initializes_properly
+  def test_initializes_properly_with_args
     foo = "fooooo"
     bar = "baaarrrr"
     storer = ArgumentativeStorer.new(foo, bar)
@@ -24,9 +29,30 @@ class InitializerInjectorTest < Minitest::Test
     assert_equal bar, storer.send(:bar)
   end
 
+  def test_initializes_properly_with_keyword_args
+    foo = "fooooo"
+    bar = "baaarrrr"
+    storer = KeywordStorer.new(foo, bar: bar)
+    assert_equal foo, storer.send(:foo)
+    assert_equal bar, storer.send(:bar)
+  end
+
+  def test_initializes_properly_with_a_missing_keyword_arg
+    foo = "fooooo"
+    storer = KeywordStorer.new(foo)
+    assert_equal foo, storer.send(:foo)
+    assert_equal ["default"], storer.send(:bar)
+  end
+
   def test_raises_with_wrong_amount_of_args
     assert_raises ArgumentError do
       ArgumentativeStorer.new(nil)
+    end
+  end
+
+  def test_raises_with_wrong_keyword_args
+    assert_raises ArgumentError do
+      KeywordStorer.new("foo", qux: "bar")
     end
   end
 


### PR DESCRIPTION
Replaces #3. Thanks @AndrewRadev. Sorry this took ages to look at.

I've added some new tests (and code) in response to this Ruby 2.7 warning:
```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

@kntsoriano, @dougal, @AndrewRadev You probably all know this best so I'll tag you as reviewers if you're interested. I'll merge it at the weekend and release a new version if no-one raises any objections before I get to it :)

