### PR TITLE
Add POC for ActiveSupport::Notifications

### DIFF
--- a/lib/mandate.rb
+++ b/lib/mandate.rb
@@ -10,4 +10,34 @@ module Mandate
     base.extend(CallInjector)
     base.extend(InitializerInjector)
   end
+
+  def self.use_notifications!
+    Config.instance.use_notifications!
+  end
+
+  def self.use_notifications?
+    !!Config.instance.use_notifications
+  end
+
+  class Config
+    include Singleton
+
+    attr_reader :use_notifications
+
+    def use_notifications!
+      begin
+        require 'active_support/notifications'
+      rescue StandardError => e
+        puts "ActiveSupport must be in the Gemfile to use notifications"
+        raise e
+      end
+
+      @use_notifications = true
+    end
+
+    # Used in the tests
+    def do_not_use_notifications!
+      @use_notifications = false
+    end
+  end
 end

--- a/lib/mandate/call_injector.rb
+++ b/lib/mandate/call_injector.rb
@@ -10,12 +10,20 @@ module Mandate
           # If the last argument is a hash and the last param is a keyword params (signified by
           # its type being :key, the we should pass the hash in in using the **kwords syntax.
           # This fixes a deprecation issue in Ruby 2.7.
-          if args.last.is_a?(Hash) &&
-             instance_method(:initialize).parameters.last&.first == :key
-            new(*args[0..-2], **args[-1]).()
-          else
-            new(*args).()
+          with_notifications do
+            if args.last.is_a?(Hash) &&
+               instance_method(:initialize).parameters.last&.first == :key
+              new(*args[0..-2], **args[-1]).()
+            else
+              new(*args).()
+            end
           end
+        end
+
+        def with_notifications(&block)
+          return yield unless Mandate.use_notifications?
+
+          ActiveSupport::Notifications.instrument('call.mandate', command: self.name, &block)
         end
       end
     end

--- a/mandate.gemspec
+++ b/mandate.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "activesupport", "~> 6.1"
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 12.3"

--- a/test/call_injector_test.rb
+++ b/test/call_injector_test.rb
@@ -123,4 +123,23 @@ class CallInjectorTest < Minitest::Test
   def test_empty_intitializer
     assert_equal 1, OneSumer.()
   end
+
+  def test_notifications
+    Mandate.use_notifications!
+
+    events = []
+
+    ActiveSupport::Notifications.subscribe('call.mandate') do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    assert_equal 1, OneSumer.()
+
+    assert_equal 1, events.size
+    event = events.first
+    assert_equal 'call.mandate', event.name
+    assert_equal({ command: "CallInjectorTest::OneSumer" }, event.payload)
+  ensure
+    Mandate::Config.instance.do_not_use_notifications!
+  end
 end


### PR DESCRIPTION
I would like to have notifications for commands instrumented in Skylight as it will make it infinitely more useful for Exercism (and other apps that rely on Mandate). This is a POC to discuss with the Skylight team.