### PR TITLE
Allow capture `kwargs` as object

### DIFF
--- a/lib/mandate/initializer_injector.rb
+++ b/lib/mandate/initializer_injector.rb
@@ -2,12 +2,20 @@ require 'securerandom'
 
 module Mandate
   NO_DEFAULT = SecureRandom.uuid
+  CAPTURE_KWARGS_ATTR = :attributes
 
   module InitializerInjector
     def self.extended(base)
       class << base
         def initialize_with(*attrs, **kwattrs, &block)
           define_method :initialize do |*args, **kwargs|
+            # If the last attribute is :attributes, store the kwargs array
+            # instead of its individual keyword values
+            if attrs.last == CAPTURE_KWARGS_ATTR
+              args << kwargs
+              kwargs = []
+            end
+
             unless args.length == attrs.length
               raise ArgumentError, "wrong number of arguments (given #{args.length}, expected #{attrs.length})"
             end

--- a/test/initializer_injector_test.rb
+++ b/test/initializer_injector_test.rb
@@ -11,6 +11,11 @@ class InitializerInjectorTest < Minitest::Test
     initialize_with :foo, :bar
   end
 
+  class AttributesStorer
+    include Mandate
+    initialize_with :foo, :bar, :attributes
+  end
+
   class KeywordStorer
     include Mandate
     initialize_with :foo, optional: "default", compulsary: Mandate::NO_DEFAULT
@@ -38,6 +43,13 @@ class InitializerInjectorTest < Minitest::Test
     storer = ArgumentativeStorer.new(foo, bar)
     assert_equal foo, storer.send(:foo)
     assert_equal bar, storer.send(:bar)
+  end
+
+  def test_initializes_properly_with_attributes
+    foo = "fooooo"
+    bar = "baaarrrr"
+    attrs = AttributesStorer.new(foo, bar, add: 1, to: 2)
+    assert_equal ({ add: 1, to: 2 }), attrs.send(:attributes)
   end
 
   def test_initializes_properly_with_keyword_args


### PR DESCRIPTION
Currently, any `kwargs` values passed to an initializer are automatically assigned to individual keyword parameters.
Previously, one could capture _all_ kwargs values by having a special `attributes` parameter.
